### PR TITLE
Remove wasm-tool plugin

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: CD
 
 on:
   push:
-    branches: [ main ]
+    branches: main
   workflow_dispatch:
 
 jobs:
@@ -14,7 +14,11 @@ jobs:
         with:
           persist-credentials: false
         
-      - name: Install and build
+      - name: Build wasm module
+        working-directory: ./src/tilemap
+        run: wasm-pack build --release --no-typescript
+
+      - name: Install and build React app
         run: |
           curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
           yarn install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:
@@ -21,14 +21,6 @@ jobs:
     - name: Install wasm-pack
       run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-    - name: Install node dependencies
-      run: yarn install
-
-    - name: Test React
-      run: yarn test
-      env:
-        CI: true
-
     - name: Test WASM on Chrome
       working-directory: ./src/tilemap
       run: wasm-pack test --headless --chrome
@@ -36,3 +28,11 @@ jobs:
     - name: Test WASM on Firefox
       working-directory: ./src/tilemap
       run: wasm-pack test --headless --firefox
+
+    - name: Install node dependencies
+      run: yarn install
+
+    - name: Test React
+      run: yarn test
+      env:
+        CI: true

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const { override, addPostcssPlugins } = require("customize-cra");
 
-const WasmPackPlugin = require("@wasm-tool/wasm-pack-plugin");
+//const WasmPackPlugin = require("@wasm-tool/wasm-pack-plugin");
 
 module.exports = override(
   // Ignore wasm files on file loader
@@ -18,18 +18,18 @@ module.exports = override(
     return config;
   },
 
-  // Hook canvas Rust-WASM module
-  config => {
-    config.plugins = (config.plugins || []).concat([
-      new WasmPackPlugin({
-        crateDirectory: path.resolve(__dirname, "./src/tilemap"),
-        extraArgs: "--no-typescript",
-        outDir: path.resolve(__dirname, "./src/tilemap/pkg")
-      })
-    ]);
+  //// Hook canvas Rust-WASM module
+  //config => {
+    //config.plugins = (config.plugins || []).concat([
+      //new WasmPackPlugin({
+        //crateDirectory: path.resolve(__dirname, "./src/tilemap"),
+        //extraArgs: "--no-typescript",
+        //outDir: path.resolve(__dirname, "./src/tilemap/pkg")
+      //})
+    //]);
 
-    return config;
-  },
+    //return config;
+  //},
 
   addPostcssPlugins([
     require('tailwindcss'),

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.2",
     "@testing-library/user-event": "^12.2.2",
-    "@wasm-tool/wasm-pack-plugin": "^1.3.1",
     "gl-matrix": "^3.3.0",
     "idb-keyval": "^3.2.0",
     "react": "^17.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1958,15 +1958,6 @@
     "@typescript-eslint/types" "4.9.1"
     eslint-visitor-keys "^2.0.0"
 
-"@wasm-tool/wasm-pack-plugin@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@wasm-tool/wasm-pack-plugin/-/wasm-pack-plugin-1.3.1.tgz#eb8dbeeb3c0ce9af413347d3332485b9f5d4f103"
-  integrity sha512-8AXgN80fbbLvuROYuNsBow/MiK+VeNCzZ3WyCxwZKMIyISd1WwompVG0pLMypXd4rYnttsRyXvQqW3vDdoXZRg==
-  dependencies:
-    chalk "^2.4.1"
-    command-exists "^1.2.7"
-    watchpack "^1.6.0"
-
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
@@ -3337,11 +3328,6 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
-
-command-exists@^1.2.7:
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.9.tgz#c50725af3808c8ab0260fd60b01fbfa25b954f69"
-  integrity sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==
 
 commander@^2.20.0:
   version "2.20.3"
@@ -11276,7 +11262,7 @@ watchpack-chokidar2@^2.0.1:
   dependencies:
     chokidar "^2.1.8"
 
-watchpack@^1.6.0, watchpack@^1.7.4:
+watchpack@^1.7.4:
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==


### PR DESCRIPTION
The tool was causing incopatibilities when deploying. The memory file
was not being generated in a expected manner. See #72: https://github.com/wasm-tool/wasm-pack-plugin/issues/72